### PR TITLE
Hotfix/corrección texto certificaciones

### DIFF
--- a/helpers/documentos.go
+++ b/helpers/documentos.go
@@ -286,7 +286,7 @@ func ConstruirDocumento(nombre string, proyecto_curricular string, docentes_incu
 	pdf.Ln(lineHeight + 18)
 
 	pdf.SetFont(Calibri, "", fontSize)
-	pdf.MultiCell(0, lineHeight+1, "Los Docentes de Vinculación Especial contratados para el periodo Académico "+periodo+", del Proyecto Curricular de "+proyecto+" cumplieron a cabalidad con las funciones docentes durante el mes de "+mes+" de "+anio+" (según calendario académico).", "", "J", false)
+	pdf.MultiCell(0, lineHeight+1, "Los Docentes de Vinculación Especial contratados para el periodo Académico "+periodo+", del Proyecto Curricular de "+proyecto+" cumplieron con las actividades propias de su vinculación durante el mes de "+mes+" del año "+anio+".", "", "J", false)
 	pdf.Ln(lineHeight * 3)
 
 	if docentes_incumplidos != nil {

--- a/helpers/pago.go
+++ b/helpers/pago.go
@@ -394,7 +394,7 @@ func ConstruirDocumentoOrdenador(nombre string, facultad string, dependencia str
 	pdf.Ln(lineHeight + 18)
 
 	pdf.SetFont(Calibri, "", fontSize)
-	pdf.MultiCell(0, lineHeight+1, "De acuerdo a la información suministrada por los proyectos curriculares de la "+dependencia_nombre+", los profesores de Vinculación Especial contratados para el periodo académico "+periodo+", cumplieron a cabalidad con las funciones docentes en el mes de "+mes+" del presente año.(De acuerdo a calendario académico)", "", "J", false)
+	pdf.MultiCell(0, lineHeight+1, "De acuerdo a la información suministrada por los proyectos curriculares de la "+dependencia_nombre+", los profesores de Vinculación Especial contratados para el periodo académico "+periodo+", cumplieron con las actividades propias de su vinculación durante el mes de "+mes+" del año "+anio+".", "", "J", false)
 	pdf.Ln(lineHeight * 3)
 
 	if docentes_incumplidos != nil {


### PR DESCRIPTION
Teniendo en cuenta el requerimiento desde Vicerrectoria Academica mencionado en la tarea iris [C-015971](https://iris.portaloas.udistrital.edu.co/scp/tasks.php?id=15790), se hace el cambio del texto en las certificaciones de coorfinador y decano.